### PR TITLE
Add 404 page which fits the rest of the theme

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,16 @@
+{% extends "index.html" %}
+
+{% block title %}
+404
+{% endblock title %}
+
+{% block header_menu %}
+{{ menu_macros::menu_for(config=config, current_item="") }}
+{% endblock header_menu %}
+
+{% block content %}
+<div class="post">
+  <h1 class="post-title">Lost?</h1>
+  <p>This page does not exist.</p>
+</div>
+{% endblock content %}

--- a/templates/404.html
+++ b/templates/404.html
@@ -10,7 +10,7 @@
 
 {% block content %}
 <div class="post">
-  <h1 class="post-title">Lost?</h1>
-  <p>This page does not exist.</p>
+  <h1 class="post-title">{% block heading %}Lost?{% endblock heading %}</h1>
+  <p>{% block message %}This page does not exist.{% endblock message %}</p>
 </div>
 {% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -45,7 +45,9 @@
             </div>
         </div>
 
+        {% block header_menu %}
         {{ menu_macros::menu(config=config, current_path=current_path) }}
+        {% endblock header_menu %}
     </header>
     {% endblock header %}
 

--- a/templates/macros/menu.html
+++ b/templates/macros/menu.html
@@ -2,8 +2,6 @@
     {%- if config.extra.menu_items %}
         {%- set menu_items = config.extra.menu_items -%}
 
-        <nav class="menu">
-            <ul class="menu__inner">
             {%- for item in menu_items %}
                 {%- set abs_item_url = item.url | replace(from="$BASE_URL", to=config.base_url) -%}
                 {%- set is_current = current_url == abs_item_url ~ "/"
@@ -27,6 +25,16 @@
                 {%- set current_item = base_item -%}
             {% endif -%}
 
+            {{ menu_macros::menu_for(config=config, current_item=current_item) }}
+    {% endif -%}
+{% endmacro menu %}
+
+{% macro menu_for(config, current_item) %}
+    {%- if config.extra.menu_items %}
+        {%- set menu_items = config.extra.menu_items -%}
+
+        <nav class="menu">
+            <ul class="menu__inner">
             {%- for item in menu_items %}
                 <li {%- if current_item and current_item == item %} class="active" {%- endif %}>
                     {%- if item.newtab -%}


### PR DESCRIPTION
* Noting that (as of 0.14) zola does not pass much of a context when
  rendering the 404 page, so things like current URL/path aren't
  available
* To work around this the `menu` macro has been split into `menu_for`
  which accepts a parameter for which item is active.
* The previous macro continues to work as is, forwarding the results of
  figuring out which item is active to the new `menu_for` macro
* The added 404 page will then use the `menu_for` macro and pass in a
  blank item