### PR TITLE
Fix .posts overflowing .content

### DIFF
--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -1,0 +1,6 @@
+.post {
+    img {
+        border: 2px solid;
+        border-radius: 8px;
+    }
+}

--- a/sass/post.scss
+++ b/sass/post.scss
@@ -1,6 +1,7 @@
 @import "variables";
 
 .posts {
+  width     : 100%;
   margin: 0 auto;
 }
 

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -6,3 +6,5 @@
 @import 'post';
 @import 'pagination';
 @import 'footer';
+
+@import 'custom';


### PR DESCRIPTION
Simple fix for Issue #12 

Please ignore the changes on other files than `sass/post.scss`, for some reason  pulled 2 commits.

Closes #12.