### PR TITLE
Added the option to only show the description

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -65,7 +65,11 @@
             {%- for page in show_pages %}
                 <div class="post on-list">
                     {{ post_macros::header(page=page) }}
-                    {{ post_macros::content(page=page, summary=true) }}
+                    {%- if config.extra.show_only_description %}
+                        {{ page.description}}
+                    {% else %}
+                        {{ post_macros::content(page=page, summary=true) }}
+                    {% endif -%}
                 </div>
             {% endfor -%}
             <div class="pagination">


### PR DESCRIPTION
Since the Hugo Theme only shows the description, what I prefer, I added this option here as well.\
Updating the Zola page to show that this new option exist should be done as well, but I don’t know If this is possible from git hub.\
Maybe  add something like this:
```
#Shows only the posts title and description.
#Description is added by adding
# +++
# description = “The description”
# +++
#To the header.
show_only_description = true
```

This would be my first contribution on git hub so sorry in advance if I messed something up with the pull and push requests. 
