### PR TITLE
Fix RSS generation

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     <title>{%- block title %}{{ config.title }}{% endblock title -%}</title>
     {{ head_macros::head(config=config) }}
 
-    {%- if config.generate_rss %}
+    {%- if config.generate_feed %}
         <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path="rss.xml") | safe }}">
     {% endif -%}
 


### PR DESCRIPTION
Since [0.11](https://github.com/getzola/zola/blob/master/CHANGELOG.md#0110-2020-05-25), Zola renamed this option to config.generate_feed.