### PR TITLE
Add extra_body block to index.html

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -116,6 +116,8 @@
     {% endblock footer %}
 
 </div>
+{%- block extra_body %}
+{% endblock extra_body -%}
 </body>
 
 </html>


### PR DESCRIPTION
This enables theme users to add HTML snippets to all the pages in the blog (like an analytics snippet).

Yes the theme already has an extra_head block! but it is best for performance to put these sort of snippets right before the closing body tag.