### PR TITLE
Automatically set link to RSS or ATOM feed

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,12 @@ title = "Zola Terminimal theme"
 # Sass compilation is required
 compile_sass = true
 
+# The theme supports feeds (RSS and ATOM)
+generate_feed = true
+
+# Use `rss.xml` for RSS feeds and `atom.xml` for ATOM.
+feed_filename = "atom.xml"
+
 # Optional: enable tags
 taxonomies = [
     {name = "tags"}

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,12 @@
     {{ head_macros::head(config=config) }}
 
     {%- if config.generate_feed %}
-        <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path="rss.xml") | safe }}">
+        {%- if "rss" in config.feed_filename %}
+            {% set feed_type = 'rss+xml' %}
+        {%- else %}
+            {% set feed_type = 'atom+xml' %}
+        {% endif -%}
+        <link rel="alternate" type="application/{{ feed_type }}" title="RSS" href="{{ get_url(path=config.feed_filename) | safe }}">
     {% endif -%}
 
     {%- if config.extra.favicon %}


### PR DESCRIPTION
When generating the HTML for the feed, set the `<link >` type to either `application/rss+xml` or `application/atom+xml` according to the `feed_filename` from `config.toml`. Currently, the theme assumes the user uses RSS, without an option to change to ATOM.

I don't think this is the "bestest" approach, but I prefer guessing default feed filenames than adding another configuration option. Unless I am missing something, which is totally possible. Suggestions are very welcome.

@pawroman should I also add a note in the `README.md` about this?

Based on the [Zola docs for feeds](https://www.getzola.org/documentation/templates/feeds/).

Closes #48 