### PR TITLE
Fix: shortcode images don't load after build

### DIFF
--- a/templates/shortcodes/image.html
+++ b/templates/shortcodes/image.html
@@ -1,3 +1,8 @@
 {% if src %}
+  {# If the image's URL is internal to the site... #}
+  {% if src is not starting_with("http") %}
+    {# ... then prepend the site's base URL to the image's URL. #}
+    {% set src = config.base_url ~ src %}
+  {% endif %}
   <img src="{{ src | safe }}"{% if alt %} alt="{{ alt }}"{% endif %} class="{% if position %}{{ position }}{% else -%} center {%- endif %}" {%- if style %} style="{{ style | safe }}" {%- endif %} />
 {% endif %}


### PR DESCRIPTION
### Issue

This fixes an [issue](https://github.com/pawroman/zola-theme-terminimal/issues/36) where images added with the [`image` shortcode](https://github.com/pawroman/zola-theme-terminimal#image) are visible via `zola serve` but not `zola build`.

### Solution

It works by [prepending](https://tera.netlify.app/docs#concatenation) the site's base URL to external image URLs so `https://www.awesomesite.com/flower.png` is just as valid as `http://127.0.0.1:1111/flower.png`.

External images are differentiated from internal images by the presence of `http` at the beginning of their URL.

Fixes issue #36.