### PR TITLE
Fix: link the top-left logo to `logo_home_link` when `logo_home_link` is set

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -29,8 +29,8 @@
     <header class="header">
         <div class="header__inner">
             <div class="header__logo">
-                {%- if config.logo_home_link %}
-                    {% set logo_link = config.logo_home_link %}
+                {%- if config.extra.logo_home_link %}
+                    {% set logo_link = config.extra.logo_home_link %}
                 {% else %}
                     {% set logo_link = config.base_url %}
                 {% endif -%}


### PR DESCRIPTION
### Issue

The bug is caused by the first missing `.extra`, which makes Tera assume that `logo_home_link` variable doesn't exist, so the `if` trigger for using it never fires. This means that the logo will always link to the default value of `base_url`.

The second missing `.extra` comes after the `if` fires. It's used to set the value of `logo_link` to `logo_home_link`.

### Solution

This fix works by adding missing two missing `.extra`'s when accessing the `logo_home_link` in the `header` template block.

### Context

My current workaround is to extend the `header` block with the fix proposed here.