### PR TITLE
Fix: Use `resize_image` Built-in Function to Generate Image URLs

### DIFF
--- a/templates/shortcodes/image.html
+++ b/templates/shortcodes/image.html
@@ -1,8 +1,10 @@
 {% if src %}
   {# If the image's URL is internal to the site... #}
   {% if src is not starting_with("http") %}
-    {# ... then prepend the site's base URL to the image's URL. #}
-    {% set src = config.base_url ~ src %}
+    {# ... then convert the page's colocated_path attribute to a string so it can be concatenated... #}
+    {% set colocated_path = page.colocated_path | as_str %}
+    {# ... and use `resize_image` to get image's URL for colocated blog posts and non-colocated blog posts. #}
+    {% set image = resize_image(path=colocated_path ~ src, width=5000, height=5000, op="fit") %}
   {% endif %}
   <img src="{{ src | safe }}"{% if alt %} alt="{{ alt }}"{% endif %} class="{% if position %}{{ position }}{% else -%} center {%- endif %}" {%- if style %} style="{{ style | safe }}" {%- endif %} decoding="async" loading="lazy"/>
 {% endif %}


### PR DESCRIPTION
# Fix Broken URLs Generated by the [`image` Shortcode](https://github.com/pawroman/zola-theme-terminimal#image)

## 🪲 Issue

Zola doesn't seem to offer a universal way of getting an image's relative path. What works for a blog with colocated assets breaks in a blog with non-colocated assets. The root issue may have to do with dates not being stripped from permalink-generating built-in functions like [`get_url`](https://www.getzola.org/documentation/templates/overview/#get-url). See [here](https://github.com/pawroman/zola-theme-terminimal/pull/43#issuecomment-1595203834) for a deeper discussion.

## 🔨 Solution

Using [`resize_image`](https://www.getzola.org/documentation/content/image-processing/) generates a valid image URL for colocated and non-colocated blog posts. We use [`fit`](https://www.getzola.org/documentation/content/image-processing/#fit) with `width` and `height` set to 5000 so no resizing actually occurs. This is admittedly hacky, but it'll fix Terminimal sites while the Zola repo either adds a new built-in function, fixes(?) `get_url`, or tells me that I've got it all wrong. 😉

## 📚 Context

Fixes issue #42, which was created by (fix) PR #37 ([source comment](https://github.com/pawroman/zola-theme-terminimal/pull/37#issuecomment-1575703464)), which was troubleshooted and redesigned in draft PR #43.

## 🔮 Future

This fix should probably be preemptively applied to [`figure` shortcodes](https://github.com/pawroman/zola-theme-terminimal#image) as well.

We may want to add image resizing args to the `image` shortcode so Terminimal blogs look nice on smaller screens.

## 🙌🏻 Kudos

Special thanks to @ipetkov for notifying us of the change and for spectacular help with troubleshooting the introduced issue. Thanks to @pawroman for coordinating and for filing issue #42. 