### PR TITLE
Fix markdown in caption of figures

### DIFF
--- a/templates/shortcodes/figure.html
+++ b/templates/shortcodes/figure.html
@@ -2,7 +2,7 @@
   <figure class="{% if position %}{{ position }}{% else -%} center {%- endif %}" >
     <img src="{{ src | safe }}"{% if alt %} alt="{{ alt }}"{% endif %}{% if style %} style="{{ style }}"{% endif %} />
     {% if caption %}
-      <figcaption class="{% if caption_position %}{{ caption_position }}{% else -%} center {%- endif %}"{% if caption_style %} style="{{ caption_style | safe }}"{% endif %}>{{ caption }}</figcaption>
+      <figcaption class="{% if caption_position %}{{ caption_position }}{% else -%} center {%- endif %}"{% if caption_style %} style="{{ caption_style | safe }}"{% endif %}>{{ caption | markdown() | safe }}</figcaption>
     {% endif %}
   </figure>
 {% endif %}


### PR DESCRIPTION
The `figure` shortcode does not allow Markdown markup in captions. I'm not sure this is by design, but this PR changes it so we can use Markdown in captions.

For example, this snippet:

```
{{ figure(src="foo.jpg",
          position="center",
          caption="Foo _bar_ **baz** [link](http://google.com)",
          caption_position="center") }}
```

is currently rendered this way:
![without-fix](https://github.com/pawroman/zola-theme-terminimal/assets/13461702/c73637c9-e3ca-4191-a48e-fabde4b3248a)

After this patch it becomes:
![with-fix](https://github.com/pawroman/zola-theme-terminimal/assets/13461702/83c4cd93-7f9a-4f40-9128-b6a462352c2c)

Quite handy in my opinion.