### PR TITLE
Added the option to only show the description (continuation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ Example:
 
 ## Configuration
 
+### Only show the post's description
+
+On each post you can specify the following:
+
+```toml
+description = "test description"
+
+[extra]
+show_only_description = true
+```
+
+This will render `test description` under this
+particular post on the homepage instead of a summary.
+
 ### Colors
 
 Both the accent colors and background colors are

--- a/templates/index.html
+++ b/templates/index.html
@@ -71,7 +71,8 @@
             {%- for page in show_pages %}
                 <div class="post on-list">
                     {{ post_macros::header(page=page) }}
-                    {{ post_macros::content(page=page, summary=true) }}
+
+                    {{ post_macros::content(page=page, summary=true, show_only_description=page.extra.show_only_description | default(value=false)) }}
                 </div>
             {% endfor -%}
             <div class="pagination">

--- a/templates/macros/post.html
+++ b/templates/macros/post.html
@@ -1,5 +1,9 @@
-{% macro content(page, summary) %}
-    {%- if summary and page.summary %}
+{% macro content(page, summary, show_only_description) %}
+    {%- if show_only_description %}
+        <div class="post-content">
+            {{ page.description | safe }}
+        </div>
+    {% elif summary and page.summary %}
         <div class="post-content">
             {{ page.summary | safe }}
         </div>

--- a/templates/page.html
+++ b/templates/page.html
@@ -7,7 +7,7 @@
 {% block content %}
     <div class="post">
         {{ post_macros::header(page=page) }}
-        {{ post_macros::content(page=page, summary=false) }}
+        {{ post_macros::content(page=page, summary=true, show_only_description=false) }}
         {{ post_macros::earlier_later(page=page) }}
     </div>
 {% endblock content %}


### PR DESCRIPTION
A continuation of [this](https://github.com/pawroman/zola-theme-terminimal/pull/21) PR.

Not sure if you want to add anything to the docs or if you want me to place the added paragraph somewhere else, let me know :)

For testing I just added the `toml` I use in the example in the `welcome-terminimal-theme.md` file.

- Added the option to only show the description
- Include `show_only_description` in docs
