### PR TITLE
Fix `show_only_description` breaking page rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Example:
 
 Same as `image`, but with a few extra optional arguments:
 
-- **`caption`**
+- **`caption`** (supports markdown)
 - **`caption_position`** (center \[default\] | left | right)
 - **`caption_style`**
 
@@ -97,8 +97,8 @@ Example:
           style="width: 25%;",
           position="right",
           caption_position="left",
-          caption="Ferris, the (unofficial) Rust mascot",
-          caption_style="font-weight: bold; font-style: italic;") }}
+          caption="**Ferris**, the (unofficial) Rust mascot",
+          caption_style="font-style: italic;") }}
 ```
 
 ## OpenGraph

--- a/content/welcome-terminimal-theme.md
+++ b/content/welcome-terminimal-theme.md
@@ -77,7 +77,7 @@ figure(src="http://rustacean.net/assets/rustacean-flat-gesture.png",
        style="width: 25%;",
        position="center",
        caption_position="left",
-       caption="Ferris, the (unofficial) Rust mascot",
+       caption="**Ferris**, the (unofficial) Rust mascot",
        caption_style="font-weight: bold; font-style: italic;")
 ```
 
@@ -85,8 +85,8 @@ figure(src="http://rustacean.net/assets/rustacean-flat-gesture.png",
           style="width: 25%;",
           position="center",
           caption_position="left",
-          caption="Ferris, the (unofficial) Rust mascot",
-          caption_style="font-weight: bold; font-style: italic;") }}
+          caption="**Ferris**, the (unofficial) Rust mascot",
+          caption_style="font-style: italic;") }}
 
 ---
 

--- a/templates/macros/post.html
+++ b/templates/macros/post.html
@@ -15,6 +15,7 @@
             </a>
         </div>
     {% else %}
+        {#- full content -#}
         <div class="post-content">
             {{ page.content | safe }}
         </div>

--- a/templates/page.html
+++ b/templates/page.html
@@ -7,7 +7,7 @@
 {% block content %}
     <div class="post">
         {{ post_macros::header(page=page) }}
-        {{ post_macros::content(page=page, summary=true, show_only_description=false) }}
+        {{ post_macros::content(page=page, summary=false, show_only_description=false) }}
         {{ post_macros::earlier_later(page=page) }}
     </div>
 {% endblock content %}


### PR DESCRIPTION
- Fix `show_only_description` breaking page rendering (reported by @BettridgeKameron https://github.com/pawroman/zola-theme-terminimal/commit/39d13a9a6a1b7b6aaaa3e567ccdb978d8d0ceced#commitcomment-135136633)
- Update README and examples to mention markdown support in the `figure` shortcode