### PR TITLE
shortcodes: use async and lazy for images.

### DIFF
--- a/templates/shortcodes/figure.html
+++ b/templates/shortcodes/figure.html
@@ -1,6 +1,6 @@
 {% if src %}
   <figure class="{% if position %}{{ position }}{% else -%} center {%- endif %}" >
-    <img src="{{ src | safe }}"{% if alt %} alt="{{ alt }}"{% endif %}{% if style %} style="{{ style }}"{% endif %} />
+    <img src="{{ src | safe }}"{% if alt %} alt="{{ alt }}"{% endif %}{% if style %} style="{{ style }}"{% endif %} decoding="async" loading="lazy"/>
     {% if caption %}
       <figcaption class="{% if caption_position %}{{ caption_position }}{% else -%} center {%- endif %}"{% if caption_style %} style="{{ caption_style | safe }}"{% endif %}>{{ caption | markdown() | safe }}</figcaption>
     {% endif %}

--- a/templates/shortcodes/image.html
+++ b/templates/shortcodes/image.html
@@ -4,5 +4,5 @@
     {# ... then prepend the site's base URL to the image's URL. #}
     {% set src = config.base_url ~ src %}
   {% endif %}
-  <img src="{{ src | safe }}"{% if alt %} alt="{{ alt }}"{% endif %} class="{% if position %}{{ position }}{% else -%} center {%- endif %}" {%- if style %} style="{{ style | safe }}" {%- endif %} />
+  <img src="{{ src | safe }}"{% if alt %} alt="{{ alt }}"{% endif %} class="{% if position %}{{ position }}{% else -%} center {%- endif %}" {%- if style %} style="{{ style | safe }}" {%- endif %} decoding="async" loading="lazy"/>
 {% endif %}


### PR DESCRIPTION
Zola v0.18 added an option to set all images with `decoding=async` and `load=lazy`, but this only applies to `<img>` tags generated from Markdown `![]()` syntax. This patch adds these attributes by default to `figure` and `image` macros.