### PR TITLE
tag page: add / to "all tags" link

### DIFF
--- a/templates/tags/single.html
+++ b/templates/tags/single.html
@@ -12,7 +12,7 @@
             ({{ term.pages | length }} post{{ term.pages | length | pluralize }})
         </h1>
 
-        <a href="{{ config.base_url | safe }}/tags">
+        <a href="{{ config.base_url | safe }}/tags/">
             Show all tags
         </a>
 


### PR DESCRIPTION
This is to improve Google indexing pages, for the /tags/ page. In GitHub Pages, the URL /tags does not exist per se, but is a redirect to /tags/. Google Crawler gets confused with 301 HTTP status and does not index it.

Purely for SEO purposes.