### PR TITLE
Feature: If RSS is enabled, show RSS icon in menu

### DIFF
--- a/LICENSE-Feather.md
+++ b/LICENSE-Feather.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013-2023 Cole Bemis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -355,11 +355,11 @@ This theme supports RSS feeds.
 To enable RSS you need to set those 3 configuration settings to valid values: 
 
 ```toml
-generate_feed = true
+generate_feeds = true
 author = "yourself@email.com"
 
 # Use `rss.xml` for RSS feeds and `atom.xml` for ATOM.
-feed_filename = "atom.xml"
+feed_filenames = ["rss.xml", "atom.xml"]
 ```
 
 Note that `author` is also required as part of the RSS spec.

--- a/README.md
+++ b/README.md
@@ -348,6 +348,41 @@ page_titles = "combined"
 All the configuration options are also described in
 [`config.toml`](../master/config.toml).
 
+
+### RSS
+
+This theme supports RSS feeds.
+To enable RSS you need to set those 3 configuration settings to valid values: 
+
+```toml
+generate_feed = true
+author = "yourself@email.com"
+
+# Use `rss.xml` for RSS feeds and `atom.xml` for ATOM.
+feed_filename = "atom.xml"
+```
+
+Note that `author` is also required as part of the RSS spec.
+You can read more on https://www.getzola.org/documentation/templates/feeds/ about the potential values, since RFC 4287 requires author to be a name and not an email.
+
+To add an RSS icon to the main menu, you can add this entry to the `menu_items` :
+
+```toml
+menu_items = [
+    # RSS
+    {name = "", url = "$BASE_URL/$FEED_FILENAME"}
+]
+```
+
+You can also customize the color of the RSS icon by changing the `rss_icon_color`:
+
+```toml
+[extra]
+
+# ...
+rss_icon_color = "#ee802f"
+```
+
 ## Extending
 
 Each of the templates defines named blocks, so

--- a/config.toml
+++ b/config.toml
@@ -34,6 +34,9 @@ accent_color = "blue"
 # Defaults to accent color (or, if not accent color specified, to blue).
 background_color = "blue"
 
+# You can set this to any rgb hex value.
+rss_icon_color = "#ee802f"
+
 # The logo text - defaults to "Terminimal theme"
 logo_text = "Terminimal theme"
 

--- a/templates/macros/menu.html
+++ b/templates/macros/menu.html
@@ -38,30 +38,42 @@
             <ul class="menu__inner">
             {%- for item in menu_items %}
                 <li {%- if current_item and current_item == item %} class="active" {%- endif %}>
-                    {%- if item.newtab -%}
-                        <a href="{{ item.url | replace(from="$BASE_URL", to=config.base_url) | safe }}" target="_blank" rel="noopener noreferrer">{{ item.name | safe }}</a>
-                    {%- else -%}
-                        <a href="{{ item.url | replace(from="$BASE_URL", to=config.base_url) | safe }}">{{ item.name | safe }}</a>
-                    {%- endif -%}
 
                     <!-- RSS -->
                     {%- set is_rss = item.url == "$BASE_URL/$FEED_FILENAME" -%}
-                    {%- if is_rss and config.generate_feed %}
 
-                        {%- if config.feed_filename == "rss.xml" %}
-                            {% set feed_type = 'rss+xml' %}
-                        {%- else %}
-                            {% set feed_type = 'atom+xml' %}
+                    {%- if config.extra.rss_icon_color %}
+                        {%- set rss_icon_color = config.extra.rss_icon_color %}
+                    {%- else %}
+                        {%- set rss_icon_color = "#ee802f" %}
+                    {%- endif %}
+
+                    {%- if is_rss -%}
+                        {%- if config.generate_feed %}
+                            {%- if config.feed_filename == "rss.xml" %}
+                                {% set feed_type = 'rss+xml' %}
+                            {%- else %}
+                                {% set feed_type = 'atom+xml' %}
+                            {% endif -%}
+
+                            <a type="application/{{feed_type}}" title="RSS" href="{{ get_url(path=config.feed_filename) | safe }}">
+                                <svg id="rss-icon" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 32 32" fill="none" stroke="{{rss_icon_color}}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-rss">
+                                <g transform="translate(0,5)">
+                                    <path d="M4 11a9 9 0 0 1 9 9"></path>
+                                    <path d="M4 4a16 16 0 0 1 16 16"></path>
+                                    <circle cx="5" cy="19" r="1"></circle>
+                                </g>
+                                </svg>
+                            </a>
                         {% endif -%}
 
-                        <a type="application/{{feed_type}}" title="RSS" href="{{ get_url(path=config.feed_filename) | safe }}">
-                            <svg width="12" height="12" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
-                                <!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
-                                <path fill="#ee802f" d="M128.1 416c0 35.4-28.7 64-64 64S0 451.3 0 416s28.7-64 64-64 64 28.7 64 64zm175.7 47.3c-8.4-154.6-132.2-278.6-287-287C7.7 175.8 0 183.1 0 192.3v48.1c0 8.4 6.5 15.5 14.9 16 111.8 7.3 201.5 96.7 208.8 208.8 .5 8.4 7.6 14.9 16 14.9h48.1c9.1 0 16.5-7.7 16-16.8zm144.2 .3C439.6 229.7 251.5 40.4 16.5 32 7.5 31.7 0 39 0 48v48.1c0 8.6 6.8 15.6 15.5 16 191.2 7.8 344.6 161.3 352.5 352.5 .4 8.6 7.4 15.5 16 15.5h48.1c9 0 16.3-7.5 16-16.5z"/>
-                            </svg>
-                        </a>
-                    </p>
-                    {% endif -%}
+                    {%- else -%}
+                        {%- if item.newtab -%}
+                            <a href="{{ item.url | replace(from="$BASE_URL", to=config.base_url) | safe }}" target="_blank" rel="noopener noreferrer">{{ item.name | safe }}</a>
+                        {%- else -%}
+                            <a href="{{ item.url | replace(from="$BASE_URL", to=config.base_url) | safe }}">{{ item.name | safe }}</a>
+                        {%- endif -%}
+                    {%- endif -%}
 
                 </li>
             {% endfor -%}

--- a/templates/macros/menu.html
+++ b/templates/macros/menu.html
@@ -38,7 +38,6 @@
             <ul class="menu__inner">
             {%- for item in menu_items %}
                 <li {%- if current_item and current_item == item %} class="active" {%- endif %}>
-
                     {%- if item.newtab -%}
                         <a href="{{ item.url | replace(from="$BASE_URL", to=config.base_url) | safe }}" target="_blank" rel="noopener noreferrer">{{ item.name | safe }}</a>
                     {%- else -%}
@@ -47,7 +46,6 @@
 
                     <!-- RSS -->
                     {%- set is_rss = item.url == "$BASE_URL/$FEED_FILENAME" -%}
-
                     {%- if is_rss and config.generate_feed %}
                         <a type="application/rss+xml" title="RSS" href="{{ get_url(path=config.feed_filename) | safe }}">
                             <svg width="12" height="12" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">

--- a/templates/macros/menu.html
+++ b/templates/macros/menu.html
@@ -47,7 +47,14 @@
                     <!-- RSS -->
                     {%- set is_rss = item.url == "$BASE_URL/$FEED_FILENAME" -%}
                     {%- if is_rss and config.generate_feed %}
-                        <a type="application/rss+xml" title="RSS" href="{{ get_url(path=config.feed_filename) | safe }}">
+
+                        {%- if config.feed_filename == "rss.xml" %}
+                            {% set feed_type = 'rss+xml' %}
+                        {%- else %}
+                            {% set feed_type = 'atom+xml' %}
+                        {% endif -%}
+
+                        <a type="application/{{feed_type}}" title="RSS" href="{{ get_url(path=config.feed_filename) | safe }}">
                             <svg width="12" height="12" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
                                 <!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
                                 <path fill="#ee802f" d="M128.1 416c0 35.4-28.7 64-64 64S0 451.3 0 416s28.7-64 64-64 64 28.7 64 64zm175.7 47.3c-8.4-154.6-132.2-278.6-287-287C7.7 175.8 0 183.1 0 192.3v48.1c0 8.4 6.5 15.5 14.9 16 111.8 7.3 201.5 96.7 208.8 208.8 .5 8.4 7.6 14.9 16 14.9h48.1c9.1 0 16.5-7.7 16-16.8zm144.2 .3C439.6 229.7 251.5 40.4 16.5 32 7.5 31.7 0 39 0 48v48.1c0 8.6 6.8 15.6 15.5 16 191.2 7.8 344.6 161.3 352.5 352.5 .4 8.6 7.4 15.5 16 15.5h48.1c9 0 16.3-7.5 16-16.5z"/>

--- a/templates/macros/menu.html
+++ b/templates/macros/menu.html
@@ -38,11 +38,26 @@
             <ul class="menu__inner">
             {%- for item in menu_items %}
                 <li {%- if current_item and current_item == item %} class="active" {%- endif %}>
+
                     {%- if item.newtab -%}
                         <a href="{{ item.url | replace(from="$BASE_URL", to=config.base_url) | safe }}" target="_blank" rel="noopener noreferrer">{{ item.name | safe }}</a>
                     {%- else -%}
                         <a href="{{ item.url | replace(from="$BASE_URL", to=config.base_url) | safe }}">{{ item.name | safe }}</a>
                     {%- endif -%}
+
+                    <!-- RSS -->
+                    {%- set is_rss = item.url == "$BASE_URL/$FEED_FILENAME" -%}
+
+                    {%- if is_rss %}
+                        <a type="application/rss+xml" title="RSS" href="{{ get_url(path=config.feed_filename) | safe }}">
+                            <svg width="12" height="12" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+                                <!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
+                                <path fill="#ee802f" d="M128.1 416c0 35.4-28.7 64-64 64S0 451.3 0 416s28.7-64 64-64 64 28.7 64 64zm175.7 47.3c-8.4-154.6-132.2-278.6-287-287C7.7 175.8 0 183.1 0 192.3v48.1c0 8.4 6.5 15.5 14.9 16 111.8 7.3 201.5 96.7 208.8 208.8 .5 8.4 7.6 14.9 16 14.9h48.1c9.1 0 16.5-7.7 16-16.8zm144.2 .3C439.6 229.7 251.5 40.4 16.5 32 7.5 31.7 0 39 0 48v48.1c0 8.6 6.8 15.6 15.5 16 191.2 7.8 344.6 161.3 352.5 352.5 .4 8.6 7.4 15.5 16 15.5h48.1c9 0 16.3-7.5 16-16.5z"/>
+                            </svg>
+                        </a>
+                    </p>
+                    {% endif -%}
+
                 </li>
             {% endfor -%}
             </ul>

--- a/templates/macros/menu.html
+++ b/templates/macros/menu.html
@@ -49,14 +49,16 @@
                     {%- endif %}
 
                     {%- if is_rss -%}
-                        {%- if config.generate_feed %}
-                            {%- if config.feed_filename == "rss.xml" %}
-                                {% set feed_type = 'rss+xml' %}
-                            {%- else %}
-                                {% set feed_type = 'atom+xml' %}
-                            {% endif -%}
+                        {%- if config.generate_feeds %}
+                            {%- for feed in config.feed_filenames %}
+                                {%- if feed is containing('rss') %}
+                                    <a rel="alternate" type="application/rss+xml" title="RSS Feed" href="{{ get_url(path=feed, trailing_slash=false, lang=lang) | safe }}" />
+                                {% endif -%}
+                                {%- if feed is containing('atom') %}
+                                    <a rel="alternate" type="application/atom+xml" title="ATOM Feed" href="{{ get_url(path=feed, trailing_slash=false, lang=lang) | safe }}" />
+                                {% endif -%}
+                            {% endfor -%}
 
-                            <a type="application/{{feed_type}}" title="RSS" href="{{ get_url(path=config.feed_filename) | safe }}">
                                 <svg id="rss-icon" xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 32 32" fill="none" stroke="{{rss_icon_color}}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-rss">
                                 <g transform="translate(0,5)">
                                     <path d="M4 11a9 9 0 0 1 9 9"></path>

--- a/templates/macros/menu.html
+++ b/templates/macros/menu.html
@@ -48,7 +48,7 @@
                     <!-- RSS -->
                     {%- set is_rss = item.url == "$BASE_URL/$FEED_FILENAME" -%}
 
-                    {%- if is_rss %}
+                    {%- if is_rss and config.generate_feed %}
                         <a type="application/rss+xml" title="RSS" href="{{ get_url(path=config.feed_filename) | safe }}">
                             <svg width="12" height="12" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
                                 <!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->


### PR DESCRIPTION
This PR adds support for showing a tiny RSS svg badge in the top menu in case the user added a `menu_item` that looks like this:

```toml
menu_items = [
    {name = "home", url = "$BASE_URL"},

    # [...]

    # RSS
    {name = "", url = "$BASE_URL/$FEED_FILENAME"},
]
```
    
It also requires that the user has a config.toml that contains the following entries, and `generate_feed` is set to `true` :
    
```toml
generate_feed = true
feed_filename = "rss.xml"
author = "Your name here"
```

The icon would look like this:
![Screenshot 2024-06-01 at 11 51 14 AM](https://github.com/pawroman/zola-theme-terminimal/assets/10340139/eb2ec094-a28a-4d2b-bab3-fb3c8932689f)

A live example can be seen here: https://valerioviperino.me
