### PR TITLE
Add relative path support for shortcodes

### DIFF
--- a/templates/shortcodes/figure.html
+++ b/templates/shortcodes/figure.html
@@ -1,8 +1,15 @@
 {% if src %}
-  <figure class="{% if position %}{{ position }}{% else -%} center {%- endif %}" >
-    <img src="{{ src | safe }}"{% if alt %} alt="{{ alt }}"{% endif %}{% if style %} style="{{ style }}"{% endif %} decoding="async" loading="lazy"/>
-    {% if caption %}
-      <figcaption class="{% if caption_position %}{{ caption_position }}{% else -%} center {%- endif %}"{% if caption_style %} style="{{ caption_style | safe }}"{% endif %}>{{ caption | markdown() | safe }}</figcaption>
-    {% endif %}
-  </figure>
+  {# If the image's URL is internal to the site... #}
+  {% if src is not starting_with("http") %}
+    {# ... then prepend the site's base URL to the image's URL. #}
+    {% set src = get_url(path=page.colocated_path ~ src) %}
+  {% endif %}
+<figure class="{% if position %}{{ position }}{% else -%} center {%- endif %}">
+  <img src="{{ src | safe }}" {% if alt %} alt="{{ alt }}" title="{{ alt }}" {% endif %}{% if style
+    %} style="{{ style }}" {% endif %} decoding="async" loading="lazy" />
+  {% if caption %}
+  <figcaption class="{% if caption_position %}{{ caption_position }}{% else -%} center {%- endif %}" {% if caption_style
+    %} style="{{ caption_style | safe }}" {% endif %}>{{ caption | markdown() | safe }}</figcaption>
+  {% endif %}
+</figure>
 {% endif %}

--- a/templates/shortcodes/image.html
+++ b/templates/shortcodes/image.html
@@ -2,7 +2,7 @@
   {# If the image's URL is internal to the site... #}
   {% if src is not starting_with("http") %}
     {# ... then prepend the site's base URL to the image's URL. #}
-    {% set src = config.base_url ~ src %}
+    {% set src = get_url(path=page.colocated_path ~ src) %}
   {% endif %}
-  <img src="{{ src | safe }}"{% if alt %} alt="{{ alt }}"{% endif %} class="{% if position %}{{ position }}{% else -%} center {%- endif %}" {%- if style %} style="{{ style | safe }}" {%- endif %} decoding="async" loading="lazy"/>
+  <img src="{{ src | safe }}"{% if alt %} alt="{{ alt }}" title="{{ alt }}"{% endif %} class="{% if position %}{{ position }}{% else -%} center {%- endif %}" {%- if style %} style="{{ style | safe }}" {%- endif %} decoding="async" loading="lazy"/>
 {% endif %}


### PR DESCRIPTION
Hi there,

This PR does what it says on the tin. It lets you link to relative files easily:

```
{{ figure(src="xkcd-234.png", caption="[Escape artist](https://www.xkcd.com/234)") }}
```