### PR TITLE
Tweak default config to follow RSS generation changes after Zola 0.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 See the live demo (of the default configuration) here:
 https://pawroman.github.io/zola-theme-terminimal/
 
-Tested with Zola v0.17.2. Please note that earlier versions might not work because of breaking changes across Zola versions.
+Tested with Zola v0.19.2.
+
+Please note that earlier (and older) versions might not work because of breaking changes across Zola versions.
 
 #### Fork disclaimer
 

--- a/config.toml
+++ b/config.toml
@@ -6,10 +6,10 @@ title = "Zola Terminimal theme"
 compile_sass = true
 
 # The theme supports feeds (RSS and ATOM)
-generate_feed = true
+generate_feeds = true
 
 # Use `rss.xml` for RSS feeds and `atom.xml` for ATOM.
-feed_filename = "atom.xml"
+feed_filenames = ["rss.xml", "atom.xml"]
 
 # Optional: enable tags
 taxonomies = [

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,7 +24,7 @@
             {%- endif %}
 
         {%- endfor %}
-    {% endif -%}
+    {%- endif -%}
 
     {%- if config.extra.favicon %}
         <link rel="shortcut icon" type="{{ config.extra.favicon_mimetype | default(value="image/x-icon") | safe }}" href="{{ config.extra.favicon | safe }}">


### PR DESCRIPTION
A quick follow up to #71 to reflect the expected config params in default config.