### PR TITLE
Allow customizing post date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,16 @@ page_titles = "combined"
 All the configuration options are also described in
 [`config.toml`](../master/config.toml).
 
+### Post date format
+
+You can customize the format of the post date by adding:
+
+```toml
+[extra]
+# Overwrite the format to Jan 13, 2025.
+post_date_format = "%b %d, %Y"
+```
+
 ## Extending
 
 Each of the templates defines named blocks, so

--- a/config.toml
+++ b/config.toml
@@ -34,6 +34,9 @@ accent_color = "blue"
 # Defaults to accent color (or, if not accent color specified, to blue).
 background_color = "blue"
 
+# Format of the post date - defaults to "2025-01-13".
+post_date_format = "%Y-%m-%d"
+
 # The logo text - defaults to "Terminimal theme"
 logo_text = "Terminimal theme"
 

--- a/templates/macros/post.html
+++ b/templates/macros/post.html
@@ -26,7 +26,7 @@
 {% macro date(page) %}
     <span class="post-date">
         {%- if page.date %}
-            {{ page.date | date(format="%Y-%m-%d") }}
+            {{ page.date | date(format=config.extra.post_date_format) }}
         {% endif -%}
     </span>
 {% endmacro post_date %}

--- a/theme.toml
+++ b/theme.toml
@@ -30,6 +30,9 @@ accent_color = "blue"
 # Defaults to accent color (or, if not accent color specified, to blue).
 background_color = "blue"
 
+# Format of the post date - defaults to "2025-01-13".
+post_date_format = "%Y-%m-%d"
+
 # The logo text - defaults to 2 non-breaking spaces.
 logo_text = "Terminimal theme"
 


### PR DESCRIPTION
Fixes: https://github.com/pawroman/zola-theme-terminimal/issues/79

Now you can set the format of the date used in the post in the config:

```toml
[extra]
post_date_format = "%Y-%m-%d"
```