### PR TITLE
Display codeblocks correctly when linenos is given.

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -144,6 +144,34 @@ pre {
     margin: 0;
     background: none;
   }
+
+  &[data-linenos] {
+    padding: 1rem 0;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    border: none;
+    margin: 0;
+
+    td {
+      padding: 0;
+      border: none;
+
+      &:nth-of-type(1) {
+        text-align: center;
+        user-select: none;
+        width: 3.5rem;
+        color: var(--accent-alpha-20);
+      }
+    }
+  }
+
+  mark {
+    display: block;
+    background-color: rgba(254, 252, 232, 0.9);
+  }
 }
 
 blockquote {


### PR DESCRIPTION
Fixes #81

Applies to any code block that uses the `linenos` modifier such as:

    ```dockerfile,linenos
    FROM internal.registry/base/ca-bundle:20220405 AS cert-bundle

    FROM internal.registry/base/python:3.9.2-slim AS builder

    COPY --from=cert-bundle /certs/ /usr/local/share/ca-certificates/
    RUN update-ca-certificates
    ```

Before:

![image](https://github.com/user-attachments/assets/bdcd5663-87d5-413a-ab18-d30a7d6d0c68)

After:

![image](https://github.com/user-attachments/assets/08d2f4dd-4464-4aee-bce2-a1f17ac3bbae)
